### PR TITLE
set custom texts for errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decidim-friendly_signup (0.4)
+    decidim-friendly_signup (0.4.1)
       decidim-core (~> 0.26.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -90,6 +90,41 @@ Decidim::FriendlySignup.configure do |config|
 end
 ```
 
+### Customize error messages in instant validation
+
+You can customize any message either overriding in your application the files in `config/locales/*.yml` or by using a module like Term Customizer.
+
+This plugin uses a cascade-style fallback looking for a series of I18n keys and returns the first available. For instance, for the attribute `email` and the validation key `blank` it will look for these 3 possibilities, returning the first matching one:
+
+Specific attribute error:
+```yaml
+en:
+  decidim:
+    friendly_signup:
+      errors:
+        messages:
+          email:
+            blank: Please enter an email address
+```
+
+Generic error:
+```yaml
+en:
+  decidim:
+    friendly_signup:
+      errors:
+        messages:
+          blank: Looks like you haven’t entered anything in this field
+```
+
+Rails' default error:
+```yaml
+en:
+  errors:
+    messages:
+      blank: can't be blank
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/OpenSourcePolitics/decidim-module-friendly_signup.

--- a/app/packs/src/decidim/friendly_signup/lib/instant_validator.js
+++ b/app/packs/src/decidim/friendly_signup/lib/instant_validator.js
@@ -53,10 +53,15 @@ export default class InstantValidator {
   }
 
   validate($input) {
+    let $recheck = $($input.data("instantRecheck"));
     this.tamper($input);
     this.post($input).done((response) => {
       this.setFeedback(response, $input);
     });
+
+    if ($recheck.length && this.isTampered($recheck)) {
+      this.validate($recheck)
+    }
   }
 
   setFeedback(data, $input) {
@@ -82,7 +87,7 @@ export default class InstantValidator {
     }
     this.$form.foundation("addErrorClasses", $dest);
     if (msg) {
-      $dest.closest("label").find(".form-error").text(msg);
+      $dest.closest("label").find(".form-error").html(msg);
     }
   }
 

--- a/app/packs/src/decidim/friendly_signup/lib/instant_validator.js
+++ b/app/packs/src/decidim/friendly_signup/lib/instant_validator.js
@@ -81,6 +81,7 @@ export default class InstantValidator {
   }
 
   addErrors($dest, msg) {
+    console.log("$dest", $dest, "%form", this.$form)
     if ($dest.closest("label").find(".form-error").length > 1) {
       // Decidim may add and additional error class that does not play well with abide
       $dest.closest("label").find(".form-error:last").remove();

--- a/app/views/decidim/devise/invitations/edit.html.erb
+++ b/app/views/decidim/devise/invitations/edit.html.erb
@@ -10,7 +10,7 @@
 
   <div class="row">
     <div class="columns large-6 medium-10 medium-centered">
-      <%= decidim_form_for resource, namespace: "invitation", as: resource_name, url: invitation_path(resource_name, invite_redirect: params[:invite_redirect]), html: { method: :put, class: "register-form new_user" } do |f| %>
+      <%= decidim_form_for(resource, namespace: "invitation", as: resource_name, url: invitation_path(resource_name, invite_redirect: params[:invite_redirect]), html: { method: :put, class: "register-form new_user#{friendly_override_activated?(:use_instant_validation) ? ' instant-validation' : ''}" } , data: { "validation-url" => decidim_friendly_signup.validate_path }) do |f| %>
         <div class="card">
           <div class="card__content">
             <legend><%= t("sign_up_as.legend", scope: "decidim.devise.registrations.new") %></legend>
@@ -19,14 +19,16 @@
 
             <%= f.hidden_field :invitation_token %>
 
-            <div class="user-nickname">
-              <div class="field">
-                <%= f.text_field :nickname, help_text: t("devise.invitations.edit.nickname_help", organization: current_organization.name), required: "required", prefix: { value: "@", small: 1, large: 1 } %>
+            <% unless friendly_override_activated?(:hide_nickname) %>
+              <div class="user-nickname">
+                <div class="field">
+                  <%= f.text_field :nickname, help_text: t("devise.invitations.edit.nickname_help", organization: current_organization.name), required: "required", prefix: { value: "@", small: 1, large: 1 }, data: { "instant-attribute" => "nickname", "instant-recheck" => "password" } %>
+                </div>
               </div>
-            </div>
+            <% end %>
 
             <% if f.object.class.require_password_on_accepting %>
-              <%= render("decidim/friendly_signup/shared/password_fields", form: f, options: { required: "required", minlength: ::PasswordValidator::MINIMUM_LENGTH, maxlength: ::PasswordValidator::MAX_LENGTH }) %>
+              <%= render("decidim/friendly_signup/shared/password_fields", form: f, options: { required: true, autocomplete: "off", help_text: t("devise.passwords.edit.password_help", minimun_characters: ::PasswordValidator::MINIMUM_LENGTH), minlength: ::PasswordValidator::MINIMUM_LENGTH, maxlength: ::PasswordValidator::MAX_LENGTH, data: { "instant-attribute" => "password" } }) %>
             <% end %>
           </div>
         </div>

--- a/app/views/decidim/devise/passwords/edit.html.erb
+++ b/app/views/decidim/devise/passwords/edit.html.erb
@@ -10,12 +10,12 @@
     <div class="columns medium-7 large-5 medium-centered">
       <div class="card">
         <div class="card__content">
-          <%= decidim_form_for(resource, namespace: "password", as: resource_name, url: password_path(resource_name), html: { method: :put, class: "register-form new_user#{friendly_override_activated?(:use_instant_validation) ? ' instant-validation' : ''}"} , data: { "validation-url" => decidim_friendly_signup.validate_path }) do |f| %>
+          <%= decidim_form_for(resource, namespace: "password", as: resource_name, url: password_path(resource_name), html: { method: :put, class: "register-form new_user#{friendly_override_activated?(:use_instant_validation) ? ' instant-validation' : ''}" } , data: { "validation-url" => decidim_friendly_signup.validate_path }) do |f| %>
             <%= form_required_explanation %>
 
             <%= f.hidden_field :reset_password_token %>
 
-            <%= render("decidim/friendly_signup/shared/password_fields", form: f, options: { required: true, autocomplete: "off", help_text: t("devise.passwords.edit.password_help", minimun_characters: ::PasswordValidator::MINIMUM_LENGTH), data: { "instant-attribute" => "password" } }) %>
+            <%= render("decidim/friendly_signup/shared/password_fields", form: f, options: { required: true, autocomplete: "off", help_text: t("devise.passwords.edit.password_help", minimun_characters: ::PasswordValidator::MINIMUM_LENGTH), minlength: ::PasswordValidator::MINIMUM_LENGTH, maxlength: ::PasswordValidator::MAX_LENGTH, data: { "instant-attribute" => "password" } }) %>
 
             <div class="actions">
               <%= f.submit t("devise.passwords.edit.change_my_password"), class: "button expanded" %>

--- a/app/views/decidim/devise/passwords/edit.html.erb
+++ b/app/views/decidim/devise/passwords/edit.html.erb
@@ -10,12 +10,12 @@
     <div class="columns medium-7 large-5 medium-centered">
       <div class="card">
         <div class="card__content">
-          <%= decidim_form_for(resource, namespace: "password", as: resource_name, url: password_path(resource_name), html: { method: :put, class: "register-form new_user" }) do |f| %>
+          <%= decidim_form_for(resource, namespace: "password", as: resource_name, url: password_path(resource_name), html: { method: :put, class: "register-form new_user#{friendly_override_activated?(:use_instant_validation) ? ' instant-validation' : ''}"} , data: { "validation-url" => decidim_friendly_signup.validate_path }) do |f| %>
             <%= form_required_explanation %>
 
             <%= f.hidden_field :reset_password_token %>
 
-            <%= render("decidim/friendly_signup/shared/password_fields", form: f, options: { autocomplete: "off", help_text: t("devise.passwords.edit.password_help", minimun_characters: ::PasswordValidator::MINIMUM_LENGTH) }) %>
+            <%= render("decidim/friendly_signup/shared/password_fields", form: f, options: { required: true, autocomplete: "off", help_text: t("devise.passwords.edit.password_help", minimun_characters: ::PasswordValidator::MINIMUM_LENGTH), data: { "instant-attribute" => "password" } }) %>
 
             <div class="actions">
               <%= f.submit t("devise.passwords.edit.change_my_password"), class: "button expanded" %>

--- a/app/views/decidim/devise/registrations/new.html.erb
+++ b/app/views/decidim/devise/registrations/new.html.erb
@@ -34,20 +34,20 @@
 
             <div class="user-person">
               <div class="field">
-                <%= f.text_field :name, help_text: t(".username_help"), autocomplete: "off", data: { "instant-attribute": "nickname" } %>
+                <%= f.text_field :name, help_text: t(".username_help"), autocomplete: "off", data: { "instant-attribute" => "name", "instant-recheck" => "#registration_user_password"} %>
               </div>
             </div>
 
             <% unless friendly_override_activated?(:hide_nickname) %>
               <div class="user-nickname">
                 <div class="field">
-                  <%= f.text_field :nickname, help_text: t(".nickname_help", organization: current_organization.name), prefix: { value: "@", small: 1, large: 1 }, autocomplete: "off", data: { "instant-attribute": "nickname" } %>
+                  <%= f.text_field :nickname, help_text: t(".nickname_help", organization: current_organization.name), prefix: { value: "@", small: 1, large: 1 }, autocomplete: "off", data: { "instant-attribute" => "nickname", "instant-recheck" => "#registration_user_password" } %>
                 </div>
               </div>
             <% end %>
 
             <div class="field">
-              <%= f.email_field :email, autocomplete: "email", data: { "instant-attribute": "email" } %>
+              <%= f.email_field :email, autocomplete: "email", data: { "instant-attribute" => "email", "instant-recheck" => "#registration_user_password" } %>
             </div>
 
             <%= render("decidim/friendly_signup/shared/password_fields", form: f, options: { required: true, help_text: t(".password_help", minimun_characters: ::PasswordValidator::MINIMUM_LENGTH), autocomplete: "off", data: { "instant-attribute": "password" } }) %>

--- a/app/views/decidim/devise/registrations/new.html.erb
+++ b/app/views/decidim/devise/registrations/new.html.erb
@@ -34,7 +34,7 @@
 
             <div class="user-person">
               <div class="field">
-                <%= f.text_field :name, help_text: t(".username_help"), autocomplete: "off", data: { "instant-attribute" => "name", "instant-recheck" => "#registration_user_password"} %>
+                <%= f.text_field :name, help_text: t(".username_help"), autocomplete: "off", data: { "instant-attribute" => "name", "instant-recheck" => "#registration_user_password" } %>
               </div>
             </div>
 

--- a/app/views/decidim/devise/registrations/new.html.erb
+++ b/app/views/decidim/devise/registrations/new.html.erb
@@ -26,7 +26,7 @@
   <div class="row">
     <div class="columns large-6 medium-10 medium-centered">
 
-      <%= decidim_form_for(@form, namespace: "registration", as: resource_name, url: registration_path(resource_name), html: { class: "register-form new_user#{friendly_override_activated?(:use_instant_validation) && ' instant-validation'}", id: "register-form" }, data: { "validation-url": decidim_friendly_signup.validate_path }) do |f| %>
+      <%= decidim_form_for(@form, namespace: "registration", as: resource_name, url: registration_path(resource_name), html: { class: "register-form new_user#{friendly_override_activated?(:use_instant_validation) ? ' instant-validation' : ''}", id: "register-form" }, data: { "validation-url" => decidim_friendly_signup.validate_path }) do |f| %>
         <%= invisible_captcha %>
         <div class="card">
           <div class="card__content">
@@ -50,7 +50,7 @@
               <%= f.email_field :email, autocomplete: "email", data: { "instant-attribute" => "email", "instant-recheck" => "#registration_user_password" } %>
             </div>
 
-            <%= render("decidim/friendly_signup/shared/password_fields", form: f, options: { required: true, help_text: t(".password_help", minimun_characters: ::PasswordValidator::MINIMUM_LENGTH), autocomplete: "off", data: { "instant-attribute": "password" } }) %>
+            <%= render("decidim/friendly_signup/shared/password_fields", form: f, options: { required: true, help_text: t(".password_help", minimun_characters: ::PasswordValidator::MINIMUM_LENGTH), autocomplete: "off", data: { "instant-attribute" => "password" } }) %>
           </div>
         </div>
 

--- a/app/views/decidim/devise/sessions/new.html.erb
+++ b/app/views/decidim/devise/sessions/new.html.erb
@@ -1,0 +1,58 @@
+<% add_decidim_page_title(t("devise.sessions.new.sign_in")) %>
+
+<div class="wrapper">
+  <div class="row collapse">
+    <div class="row collapse">
+      <div class="columns large-8 large-centered text-center page-title">
+        <h1><%= t("devise.sessions.new.sign_in") %></h1>
+        <% if current_organization.sign_up_enabled? %>
+          <p>
+            <%= t(".are_you_new?") %>
+            <%= link_to t(".register"), new_user_registration_path %>
+          </p>
+        <% elsif current_organization.sign_in_enabled? %>
+          <p>
+            <%= t(".sign_up_disabled") %>
+          </p>
+        <% else %>
+          <p>
+            <%= t(".sign_in_disabled") %>
+          </p>
+        <% end %>
+      </div>
+    </div>
+    <% cache current_organization do %>
+      <%= render "decidim/devise/shared/omniauth_buttons" %>
+    <% end %>
+
+    <% if current_organization.sign_in_enabled? %>
+      <div class="row">
+        <div class="columns large-6 medium-centered">
+          <div class="card">
+            <div class="card__content">
+              <%= decidim_form_for(resource, namespace: "session", as: resource_name, url: session_path(resource_name), html: { class: "register-form new_user" }) do |f| %>
+                <div>
+                  <div class="field">
+                    <%= f.email_field :email %>
+                  </div>
+                  <div class="field">
+                    <%= render("decidim/friendly_signup/shared/password_fields", form: f, options: { autocomplete: "off" }) %>
+                  </div>
+                </div>
+                  <% if devise_mapping.rememberable? %>
+                    <div class="field">
+                      <%= f.check_box :remember_me %>
+                    </div>
+                  <% end %>
+                <div class="actions">
+                  <%= f.submit t("devise.sessions.new.sign_in"), class: "button expanded" %>
+                </div>
+              <% end %>
+              <%= render "decidim/devise/shared/links" %>
+            </div>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/decidim/friendly_signup/confirmation_codes/index.html.erb
+++ b/app/views/decidim/friendly_signup/confirmation_codes/index.html.erb
@@ -28,7 +28,7 @@
           <% end %>
 
           <p class="text-center">
-            <%= link_to t(".code_not_received"), decidim.user_confirmation_path(confirmation_token: confirmation_form.confirmation_token, "user[email]": user.email), method: :post, data: { confirm: t(".confirm_send_code", email: user.email) } %>
+            <%= link_to t(".code_not_received"), decidim.user_confirmation_path(confirmation_token: confirmation_form.confirmation_token, "user[email]" => user.email), method: :post, data: { confirm: t(".confirm_send_code", email: user.email) } %>
           </p>
         </div>
       </div>

--- a/app/views/decidim/friendly_signup/confirmation_codes_mailer/confirmation_instructions.html.erb
+++ b/app/views/decidim/friendly_signup/confirmation_codes_mailer/confirmation_instructions.html.erb
@@ -4,10 +4,10 @@
 
 <h3 class="email-instruction text-center" style="margin:1em 0 0.2em 0;"><%= t(".copy") %></h3>
 
-<% if @expires_at %>
-  <p class="email-small text-center"><%= t(".expires_in", time: distance_of_time_in_words(Time.now, @expires_at, scope: "decidim.friendly_signup.datetime.distance_in_words")) %></p>
-<% end %>
+<p class="stat text-center" style="margin:1em 0 0.5em 0;"><b style="font-size: 2em"><%= @code %></b></p>
 
-<p class="stat text-center" style="margin:1em 0;"><b style="font-size: 2em"><%= @code %></b></p>
+<% if @expires_at %>
+  <p class="email-small text-center" style="margin-bottom: 2em;"><%= t(".expires_in", time: distance_of_time_in_words(Time.now, @expires_at, scope: "decidim.friendly_signup.datetime.distance_in_words")) %></p>
+<% end %>
 
 <p class="email-small email-closing text-center"><%= t(".ignore").html_safe %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,13 @@ en:
         code: Confirmation code
   decidim:
     friendly_signup:
+      errors:
+        messages:
+          blank: Looks like you haven’t entered anything in this field.
+          taken: This email is already in use for another account. Try signing in or use another email
+          email:
+            invalid: The email address looks incomplete
+          too_short: The password you have entered is too short
       confirmation_code_form:
         expired: Sorry, this code has expired, please generate a new one.
         invalid: Code is invalid, please make sure to copy the code emailed to you.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,11 +8,18 @@ en:
     friendly_signup:
       errors:
         messages:
-          blank: Looks like you haven’t entered anything in this field.
-          taken: This email is already in use for another account. Try signing in or use another email
+          blank: Looks like you haven’t entered anything in this field
           email:
+            blank: Please enter an email address
             invalid: The email address looks incomplete
-          too_short: The password you have entered is too short
+            taken: This email is already in use for another account. Try signing in or use another email
+          password:
+            password_too_short: The password you have entered is too short
+            not_enough_unique_characters: The password you have entered does not have enough different characters
+            password_too_common: The password you have entered is very common - we suggest using a different password
+            name_included_in_password: The password you have entered is too similar to your name
+            nickname_included_in_password: The password you have entered is too similar to your nickname
+            email_included_in_password: The password you have entered is too similar to your email
       confirmation_code_form:
         expired: Sorry, this code has expired, please generate a new one.
         invalid: Code is invalid, please make sure to copy the code emailed to you.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,20 +6,6 @@ en:
         code: Confirmation code
   decidim:
     friendly_signup:
-      errors:
-        messages:
-          blank: Looks like you haven’t entered anything in this field
-          email:
-            blank: Please enter an email address
-            invalid: The email address looks incomplete
-            taken: This email is already in use for another account. Try signing in or use another email
-          password:
-            password_too_short: The password you have entered is too short
-            not_enough_unique_characters: The password you have entered does not have enough different characters
-            password_too_common: The password you have entered is very common - we suggest using a different password
-            name_included_in_password: The password you have entered is too similar to your name
-            nickname_included_in_password: The password you have entered is too similar to your nickname
-            email_included_in_password: The password you have entered is too similar to your email
       confirmation_code_form:
         expired: Sorry, this code has expired, please generate a new one.
         invalid: Code is invalid, please make sure to copy the code emailed to you.
@@ -88,6 +74,26 @@ en:
           x_seconds:
             one: 1 second
             other: "%{count} seconds"
+      errors:
+        messages:
+          blank: Looks like you haven’t entered anything in this field
+          email:
+            blank: Please enter an email address
+            invalid: The email address looks incomplete
+            taken: This email is already in use for another account. Try signing in
+              or use another email
+          password:
+            email_included_in_password: The password you have entered is too similar
+              to your email
+            name_included_in_password: The password you have entered is too similar
+              to your name
+            nickname_included_in_password: The password you have entered is too similar
+              to your nickname
+            not_enough_unique_characters: The password you have entered does not have
+              enough different characters
+            password_too_common: The password you have entered is very common - we
+              suggest using a different password
+            password_too_short: The password you have entered is too short
       shared:
         password_fields:
           hidden_password: Your password is hidden

--- a/lib/decidim/friendly_signup/engine.rb
+++ b/lib/decidim/friendly_signup/engine.rb
@@ -15,6 +15,7 @@ module Decidim
           resources :confirmation_codes, only: [:index, :create]
         end
         post :validate, to: "validator#validate"
+        put :validate, to: "validator#validate"
       end
 
       # Prepare a zone to create overrides
@@ -23,10 +24,10 @@ module Decidim
       config.after_initialize do
         Decidim::Devise::SessionsController.include(Decidim::FriendlySignup::NeedsHeaderSnippets)
         Decidim::Devise::RegistrationsController.include(Decidim::FriendlySignup::NeedsHeaderSnippets)
+        Decidim::Devise::PasswordsController.include(Decidim::FriendlySignup::NeedsHeaderSnippets)
+        Decidim::Devise::InvitationsController.include(Decidim::FriendlySignup::NeedsHeaderSnippets)
         Decidim::Devise::RegistrationsController.include(Decidim::FriendlySignup::RegistrationsRedirect)
         Decidim::Devise::ConfirmationsController.include(Decidim::FriendlySignup::RegistrationsRedirect)
-        Decidim::Devise::InvitationsController.include(Decidim::FriendlySignup::NeedsHeaderSnippets)
-        Decidim::Devise::PasswordsController.include(Decidim::FriendlySignup::NeedsHeaderSnippets)
         Decidim::AccountController.include(Decidim::FriendlySignup::NeedsHeaderSnippets)
         Decidim::RegistrationForm.include(Decidim::FriendlySignup::AutoNickname)
         Decidim::User.include(Decidim::FriendlySignup::NeedsRegistrationCodes)

--- a/lib/decidim/friendly_signup/engine.rb
+++ b/lib/decidim/friendly_signup/engine.rb
@@ -21,6 +21,7 @@ module Decidim
       # https://edgeguides.rubyonrails.org/engines.html#overriding-models-and-controllers
       # overrides
       config.after_initialize do
+        Decidim::Devise::SessionsController.include(Decidim::FriendlySignup::NeedsHeaderSnippets)
         Decidim::Devise::RegistrationsController.include(Decidim::FriendlySignup::NeedsHeaderSnippets)
         Decidim::Devise::RegistrationsController.include(Decidim::FriendlySignup::RegistrationsRedirect)
         Decidim::Devise::ConfirmationsController.include(Decidim::FriendlySignup::RegistrationsRedirect)

--- a/lib/decidim/friendly_signup/user_attribute_validator.rb
+++ b/lib/decidim/friendly_signup/user_attribute_validator.rb
@@ -28,7 +28,17 @@ module Decidim
       end
 
       def error
-        errors.flatten.map(&:upcase_first).join(". ") unless valid?
+        return if valid?
+
+        errors.map do |msg|
+          key = [:blank, :invalid, :taken].find { |err| msg == I18n.t(err, scope: "errors.messages") }
+          custom_error(key).presence || msg.upcase_first
+        end.join(". ")
+      end
+
+      def custom_error(key)
+        generic = I18n.t(key, scope: "decidim.friendly_signup.errors.messages", default: "")
+        I18n.t("#{attribute}.#{key}", scope: "decidim.friendly_signup.errors.messages", default: generic)
       end
 
       private

--- a/lib/decidim/friendly_signup/version.rb
+++ b/lib/decidim/friendly_signup/version.rb
@@ -5,6 +5,6 @@ module Decidim
   module FriendlySignup
     DECIDIM_VERSION = "0.26.2"
     COMPAT_DECIDIM_VERSION = "~> 0.26.0"
-    VERSION = "0.4"
+    VERSION = "0.4.1"
   end
 end

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -12,6 +12,7 @@ checksums = [
       "/app/views/decidim/devise/registrations/new.html.erb" => "a5c41982216b2a22b90816e66cb8286b",
       "/app/views/decidim/devise/passwords/edit.html.erb" => "ea44db0114e1c201cc0f490b4899b8a8",
       "/app/views/decidim/devise/invitations/edit.html.erb" => "435073cbee6b4aaa18da7932e449e6bb",
+      "/app/views/decidim/devise/sessions/new.html.erb" => "1da8569a34bcd014ffb5323c96391837",
       "/app/views/decidim/account/_password_fields.html.erb" => "1f0c1dfc65f96f258e6fad41af41c51a",
       "/app/forms/decidim/registration_form.rb" => "28b7c6ea6f80fbc461b957f705d2d20b",
       "/app/controllers/decidim/devise/registrations_controller.rb" => "abcc9270c6191f89d7b229e481b51e9a",

--- a/spec/lib/user_attribute_validator_spec.rb
+++ b/spec/lib/user_attribute_validator_spec.rb
@@ -68,7 +68,7 @@ module Decidim::FriendlySignup
     end
 
     context "when attribute has dependant validations" do
-      let(:attribute) { :password }
+      let(:attribute) { "password" }
       let(:name) { "Africa Unite 1979" }
       let(:input_value) { "africaunite1979" }
       let(:params) do
@@ -82,14 +82,76 @@ module Decidim::FriendlySignup
 
       it { is_expected.not_to be_valid }
 
-      it "returns an error message" do
-        expect(subject.error).to include("Is too similar to your name")
+      it "returns an custom message" do
+        expect(subject.error).to include("The password you have entered is too similar to your name")
       end
 
       context "and depency is ok" do
         let(:name) { "Survival" }
 
         it { is_expected.to be_valid }
+      end
+    end
+
+    context "when attribute has custom error messages" do
+      let(:attribute) { "email" }
+      let(:name) { "test" }
+      let(:input_value) { " " }
+      let(:params) do
+        {
+          name: name,
+          nickname: name,
+          password: input_value,
+          password_confirmation: input_value,
+          attribute: attribute
+        }
+      end
+
+      it "gets custom error" do
+        expect(subject.error).to include("Please enter an email address")
+      end
+
+      context "when there's no custom translation for the attribute" do
+        before do
+          allow(I18n).to receive(:t).and_call_original
+          allow(I18n).to receive(:t).with("email.blank", scope: "decidim.friendly_signup.errors.messages", default: "Looks like you haven’t entered anything in this field").and_return("")
+        end
+
+        it "returns an generic message" do
+          expect(subject.error).to include("Can't be blank")
+        end
+      end
+
+      context "and uses custom validators" do
+        let(:attribute) { "password" }
+        let(:input_value) { "test" }
+
+        it "gets custom error" do
+          expect(subject.error).to include("The password you have entered is too similar to your nickname")
+          expect(subject.error).to include("The password you have entered is too similar to your name")
+        end
+
+        context "when nickname is hidden" do
+          before do
+            allow(Decidim::FriendlySignup).to receive(:hide_nickname).and_return(true)
+          end
+
+          it "does not show nickname error" do
+            expect(subject.error).not_to include("The password you have entered is too similar to your nickname")
+            expect(subject.error).to include("The password you have entered is too similar to your name")
+          end
+        end
+
+        context "when there's no custom translation" do
+          before do
+            allow(I18n).to receive(:t).and_call_original
+            allow(I18n).to receive(:t).with("password.name_included_in_password", scope: "decidim.friendly_signup.errors.messages", default: "").and_return("")
+          end
+
+          it "returns an generic message" do
+            expect(subject.error).to include("Is too similar to your name")
+          end
+        end
       end
     end
   end

--- a/spec/system/examples/change_password_examples.rb
+++ b/spec/system/examples/change_password_examples.rb
@@ -41,4 +41,43 @@ shared_examples "on/off change passwords" do
       expect(page).to have_current_path "/"
     end
   end
+
+  context "when instant_validation is active" do
+    it "shows custom validation" do
+      visit last_email_link
+
+      within ".new_user" do
+        expect(page).not_to have_field("password_user_password_confirmation")
+
+        fill_in :password_user_password, with: "password11"
+        sleep 0.3
+
+        expect(page).to have_css(".form-error")
+        expect(page).to have_content("The password you have entered is very common - we suggest using a different password")
+
+        fill_in :password_user_password, with: "short"
+        sleep 0.3
+
+        expect(page).to have_content("The password you have entered is too short")
+      end
+    end
+  end
+
+  context "when instant_validation is not active" do
+    before do
+      allow(Decidim::FriendlySignup).to receive(:use_instant_validation).and_return(false)
+    end
+
+    it "shows custom validation" do
+      visit last_email_link
+
+      within ".new_user" do
+        fill_in :password_user_password, with: ""
+        sleep 0.3
+
+        expect(page).to have_css(".form-error")
+        expect(page).to have_content("The password is too short")
+      end
+    end
+  end
 end

--- a/spec/system/examples/change_password_examples.rb
+++ b/spec/system/examples/change_password_examples.rb
@@ -72,7 +72,7 @@ shared_examples "on/off change passwords" do
       visit last_email_link
 
       within ".new_user" do
-        fill_in :password_user_password, with: ""
+        fill_in :password_user_password, with: "short"
         sleep 0.3
 
         expect(page).to have_css(".form-error")

--- a/spec/system/examples/invitation_nickname_examples.rb
+++ b/spec/system/examples/invitation_nickname_examples.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+shared_examples "on/off invitation nickname" do
+  context "when hide nickname is active" do
+    it "hides nickname and user can register" do
+      visit last_email_link
+
+      within ".new_user" do
+        expect(page).not_to have_field("invitation_user_nickname")
+
+        fill_in :invitation_user_password, with: "pNY6h9crVtVHZbdE"
+        check :invitation_user_tos_agreement
+        check :user_newsletter_notifications
+
+        find("*[type=submit]").click
+      end
+
+      expect(page).to have_content("Your password was set successfully")
+
+      expect(Decidim::User.last).to be_valid_password("pNY6h9crVtVHZbdE")
+    end
+  end
+
+  context "when hide nickname is not active" do
+    before do
+      allow(Decidim::FriendlySignup).to receive(:hide_nickname).and_return(false)
+    end
+
+    it "shows nickname and user can register" do
+      visit last_email_link
+
+      within ".new_user" do
+        expect(page).to have_field("invitation_user_nickname")
+        fill_in :invitation_user_password, with: "pNY6h9crVtVHZbdE"
+        check :invitation_user_tos_agreement
+        check :user_newsletter_notifications
+
+        find("*[type=submit]").click
+      end
+
+      expect(page).to have_content("Your password was set successfully")
+
+      expect(Decidim::User.last).to be_valid_password("pNY6h9crVtVHZbdE")
+    end
+  end
+end
+
+shared_examples "on/off invitation instant_validation on nickname" do
+  let!(:existing) { create :user, :confirmed, organization: Decidim::Organization.last, nickname: "existing", avatar: nil }
+  before do
+    allow(Decidim::FriendlySignup).to receive(:hide_nickname).and_return(false)
+  end
+
+  context "when use_instant_validation is active" do
+    it "hides nickname and user can register" do
+      visit last_email_link
+
+      within ".new_user" do
+        fill_in :invitation_user_nickname, with: "mynickname"
+        fill_in :invitation_user_password, with: "mynickname12345"
+        sleep 0.3
+
+        expect(page).to have_content("The password you have entered is too similar to your nickname")
+
+        fill_in :invitation_user_nickname, with: "existing"
+        sleep 0.3
+        expect(page).to have_content("Has already been taken")
+      end
+    end
+  end
+
+  context "when use_instant_validation is not active" do
+    before do
+      allow(Decidim::FriendlySignup).to receive(:use_instant_validation).and_return(false)
+    end
+
+    it "shows nickname and user can register" do
+      visit last_email_link
+
+      within ".new_user" do
+        fill_in :invitation_user_nickname, with: "mynickname"
+        fill_in :invitation_user_password, with: "mynickname12345"
+        sleep 0.3
+
+        expect(page).not_to have_content("The password you have entered is too similar to your nickname")
+
+        fill_in :invitation_user_nickname, with: ""
+        sleep 0.3
+        expect(page).to have_content("There's an error in this field.")
+      end
+    end
+  end
+end

--- a/spec/system/examples/other_password_examples.rb
+++ b/spec/system/examples/other_password_examples.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+shared_examples "on/off sign in passwords" do
+  context "when override_passwords is active" do
+    before do
+      visit decidim.new_user_session_path
+    end
+
+    it "There is a show password button" do
+      expect(page).to have_css(".user-password")
+      expect(page).to have_css(".user-password title", visible: :hidden, text: "Show password")
+    end
+  end
+
+  context "when override_passwords is not active" do
+    before do
+      allow(Decidim::FriendlySignup).to receive(:override_passwords).and_return(false)
+      visit decidim.new_user_session_path
+    end
+
+    it "There is a show password button" do
+      expect(page).not_to have_css(".user-password")
+    end
+  end
+end

--- a/spec/system/examples/registration_instant_validation_examples.rb
+++ b/spec/system/examples/registration_instant_validation_examples.rb
@@ -16,7 +16,7 @@ shared_examples "on/off registration instant validation" do
         fill_in "Your name", with: " "
         sleep 0.3 # wait for the delayed triggering fetcher
 
-        expect(page).to have_content("Can't be blank. Is invalid")
+        expect(page).to have_content("Looks like you haven’t entered anything in this field")
       end
     end
 
@@ -27,12 +27,12 @@ shared_examples "on/off registration instant validation" do
         fill_in "Your email", with: " bot@matrix"
         sleep 0.3
 
-        expect(page).to have_content("Is invalid")
+        expect(page).to have_content("The email address looks incomplete")
 
         fill_in "Your email", with: "bot@matrix.org"
         sleep 0.3
 
-        expect(page).to have_content("Has already been taken")
+        expect(page).to have_content("This email is already in use for another account. Try signing in or use another email")
       end
     end
 
@@ -49,31 +49,31 @@ shared_examples "on/off registration instant validation" do
 
     it "Password is validated while writing" do
       within("#register-form") do
-        expect(page).not_to have_content("Is too short")
+        expect(page).not_to have_content("The password you have entered is too short")
 
         fill_in "Password", with: "mypas"
         sleep 0.3
 
-        expect(page).to have_content("Is too short")
+        expect(page).to have_content("The password you have entered is too short")
       end
     end
 
     it "Password validates against dynamic content" do
       within("#register-form") do
-        expect(page).not_to have_content("Is too similar to your name")
+        expect(page).not_to have_content("The password you have entered is too similar to your name")
 
         fill_in "Your name", with: "Agent Smith 1984"
         fill_in "Password", with: "agentsmith1984"
         sleep 0.3
 
-        expect(page).to have_content("Is too similar to your name")
+        expect(page).to have_content("The password you have entered is too similar to your name")
 
-        expect(page).not_to have_content("Is too common")
+        expect(page).not_to have_content("The password you have entered is very common - we suggest using a different password")
 
         fill_in "Password", with: "password11"
         sleep 0.3
 
-        expect(page).to have_content("Is too common")
+        expect(page).to have_content("The password you have entered is very common - we suggest using a different password")
       end
     end
   end
@@ -101,26 +101,26 @@ shared_examples "on/off registration instant validation" do
         fill_in "Password", with: "mypas"
         sleep 0.3
 
-        expect(page).not_to have_content("Is too short")
+        expect(page).not_to have_content("The password you have entered is too short")
       end
     end
 
     it "Password does not validate against dynamic content" do
       within("#register-form") do
-        expect(page).not_to have_content("Is too similar to your name")
+        expect(page).not_to have_content("The password you have entered is too similar to your name")
 
         fill_in "Your name", with: "Agent Smith 1984"
         fill_in "Password", with: "agentsmith1984"
         sleep 0.3
 
-        expect(page).not_to have_content("Is too similar to your name")
-        expect(page).not_to have_content("Is too common")
+        expect(page).not_to have_content("The password you have entered is too similar to your name")
+        expect(page).not_to have_content("The password you have entered is very common - we suggest using a different password")
 
         fill_in "Password", with: "password11"
         sleep 0.3
 
-        expect(page).not_to have_content("Is too similar to your name")
-        expect(page).not_to have_content("Is too common")
+        expect(page).not_to have_content("The password you have entered is too similar to your name")
+        expect(page).not_to have_content("The password you have entered is very common - we suggest using a different password")
       end
     end
   end

--- a/spec/system/invitations_spec.rb
+++ b/spec/system/invitations_spec.rb
@@ -2,7 +2,40 @@
 
 require "spec_helper"
 require_relative "examples/invitation_password_examples"
+require_relative "examples/invitation_nickname_examples"
 
 describe "Admin invite", type: :system do
+  let(:form) do
+    Decidim::System::RegisterOrganizationForm.new(params)
+  end
+
+  let(:params) do
+    {
+      name: "Gotham City",
+      reference_prefix: "JKR",
+      host: "decide.lvh.me",
+      organization_admin_name: "Fiorello Henry La Guardia",
+      organization_admin_email: "f.laguardia@example.org",
+      available_locales: ["en"],
+      default_locale: "en",
+      users_registration_mode: "enabled",
+      file_upload_settings: Decidim::OrganizationSettings.default(:upload)
+    }
+  end
+
+  before do
+    expect do
+      perform_enqueued_jobs { Decidim::System::RegisterOrganization.new(form).call }
+    end.to broadcast(:ok)
+
+    switch_to_host("decide.lvh.me")
+  end
+
   it_behaves_like "on/off invitation passwords"
+
+  it_behaves_like "on/off invitation instant_validation"
+
+  it_behaves_like "on/off invitation nickname"
+
+  it_behaves_like "on/off invitation instant_validation on nickname"
 end

--- a/spec/system/sign_in_spec.rb
+++ b/spec/system/sign_in_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require_relative "examples/other_password_examples"
+
+describe "Sign in", type: :system do
+  let(:organization) { create(:organization) }
+
+  before do
+    switch_to_host(organization.host)
+  end
+
+  it_behaves_like "on/off sign in passwords"
+end


### PR DESCRIPTION
Implements:
- [x] Customize texts for validations
- [x] email formatting
- [x] show/hide password in signin
- [x] auto validation change password
- [x] auto validation complete after invitation
- [x] re-check dependent fields on change (ie: check for password validity after changing name)
- [x] fix validating name on registration