### PR TITLE
Fix/mailer links

### DIFF
--- a/app/mailers/decidim/friendly_signup/confirmation_codes_mailer.rb
+++ b/app/mailers/decidim/friendly_signup/confirmation_codes_mailer.rb
@@ -3,6 +3,7 @@
 module Decidim
   module FriendlySignup
     class ConfirmationCodesMailer < ApplicationMailer
+      helper_method :confirm_path_url
       include Decidim::LocalisedMailer
 
       def confirmation_instructions(user, opts)
@@ -16,6 +17,15 @@ module Decidim
         with_user(user) do
           mail(to: "#{user.name} <#{@email}>", subject: I18n.t("decidim.friendly_signup.confirmation_codes.mailer.subject", organization: @organization.name, code: @code))
         end
+      end
+
+      private
+      def confirm_path_url
+        "#{root_url}#{decidim_friendly_signup.confirmation_codes_path(confirmation_token: @token)}"
+      end
+
+      def root_url
+        @root_url ||= decidim.root_url(host: @user.organization.host)[0..-2]
       end
     end
   end

--- a/app/mailers/decidim/friendly_signup/confirmation_codes_mailer.rb
+++ b/app/mailers/decidim/friendly_signup/confirmation_codes_mailer.rb
@@ -20,6 +20,7 @@ module Decidim
       end
 
       private
+
       def confirm_path_url
         "#{root_url}#{decidim_friendly_signup.confirmation_codes_path(confirmation_token: @token)}"
       end

--- a/app/views/decidim/friendly_signup/confirmation_codes_mailer/confirmation_instructions.html.erb
+++ b/app/views/decidim/friendly_signup/confirmation_codes_mailer/confirmation_instructions.html.erb
@@ -1,6 +1,6 @@
 <h1 class="text-center"><%= t(".title") %></h1>
 
-<p class="email-instructions text-center"><%= t(".subtitle", organization: link_to(@organization.name, decidim_friendly_signup.confirmation_codes_path(confirmation_token: @token))).html_safe %></p>
+<p class="email-instructions text-center"><%= t(".subtitle", organization: link_to(@organization.name, confirm_path_url)).html_safe %></p>
 
 <h3 class="email-instruction text-center" style="margin:1em 0 0.2em 0;"><%= t(".copy") %></h3>
 


### PR DESCRIPTION
Hello ! 

I'll submit to you a fix of the issue about mail's links that were sent with the confirmation code. 
Actual issue was that the link that we showed was a link that worked only on local because we matched it with the actual route (localhost:3000/friendly_signup/...), but in the case where we opened it in an other mail manager than /letter_opener, we saw that it redirected to https://friendly_signup/... because we actually never specified the root. 

If there are some changes that you want me to do feel free to tell me about it ! 