### PR TITLE
fix: Fast signup feature

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -508,6 +508,8 @@ GEM
     net-smtp (0.4.0)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.14.5-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.5-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.14.5-x86_64-linux)
@@ -794,6 +796,7 @@ GEM
     zeitwerk (2.6.12)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin-20
   x86_64-linux
 

--- a/app/controllers/decidim/friendly_signup/confirmation_codes_controller.rb
+++ b/app/controllers/decidim/friendly_signup/confirmation_codes_controller.rb
@@ -22,10 +22,6 @@ module Decidim
         render :index
       end
 
-      def skip
-        sign_in_and_redirect user
-      end
-
       private
 
       def confirmation_form

--- a/app/controllers/decidim/friendly_signup/confirmation_codes_controller.rb
+++ b/app/controllers/decidim/friendly_signup/confirmation_codes_controller.rb
@@ -33,7 +33,17 @@ module Decidim
       end
 
       def user
-        @user ||= User.find_by(confirmation_token: params[:confirmation_token], organization: current_organization)
+        @user ||= User.find_by(confirmation_token: confirmation_token, organization: current_organization)
+      end
+
+      def confirmation_token
+        confirmation_token = params[:confirmation_token]
+
+        @confirmation_token ||= if confirmation_token.is_a?(Array)
+                                  params[:confirmation_token]&.first
+                                else
+                                  params[:confirmation_token]
+                                end
       end
 
       def require_unconfirmed_user

--- a/app/forms/decidim/friendly_signup/confirmation_code_form.rb
+++ b/app/forms/decidim/friendly_signup/confirmation_code_form.rb
@@ -12,7 +12,7 @@ module Decidim
       validate :user_exists
 
       def user_code
-        code || confirmation_numbers.map(&:to_s).join.to_i
+        code || confirmation_numbers[0..3]&.join.to_i
       end
 
       private

--- a/app/views/decidim/friendly_signup/confirmation_codes/index.html.erb
+++ b/app/views/decidim/friendly_signup/confirmation_codes/index.html.erb
@@ -27,7 +27,7 @@
             </div>
             <div class="actions text-center">
               <% if Decidim.unconfirmed_access_for != 0.days && user.active_for_authentication? %>
-                <%= link_to t(".skip_confirmation", delay: Decidim.unconfirmed_access_for/86400), decidim_friendly_signup.skip_confirmation_codes_path(confirmation_token: confirmation_form.confirmation_token) %>
+                <%= link_to t(".skip_confirmation", delay: Decidim.unconfirmed_access_for/86400), decidim.root_path %>
               <% end %>
             </div>
           <% end %>

--- a/lib/decidim/friendly_signup/engine.rb
+++ b/lib/decidim/friendly_signup/engine.rb
@@ -12,9 +12,7 @@ module Decidim
 
       routes do
         devise_scope :user do
-          resources :confirmation_codes, only: [:index, :create] do
-            get :skip, on: :collection
-          end
+          resources :confirmation_codes, only: [:index, :create]
         end
         post :validate, to: "validator#validate"
         put :validate, to: "validator#validate"

--- a/spec/controllers/confirmation_codes_controller_spec.rb
+++ b/spec/controllers/confirmation_codes_controller_spec.rb
@@ -1,0 +1,95 @@
+require "spec_helper"
+
+module Decidim
+  module FriendlySignup
+    RSpec.describe ConfirmationCodesController, type: :controller do
+      routes { Decidim::FriendlySignup::Engine.routes }
+      let(:decidim_router) { Decidim::Core::Engine.routes.url_helpers }
+
+      let(:current_organization) { create(:organization) }
+      let(:valid_code) { 1234 }
+      let(:params) { { confirmation_token: user.confirmation_token, code: valid_code } }
+      let(:user) { create(:user, organization: current_organization) }
+
+      before do
+        request.env["decidim.current_organization"] = current_organization
+        allow(FriendlySignup).to receive(:use_confirmation_codes).and_return(true)
+        allow(FriendlySignup).to receive(:confirmation_code).with(user.confirmation_token).and_return(valid_code)
+        user.invite!
+      end
+
+      shared_examples_for "confirmation codes disabled" do
+        before do
+          allow(FriendlySignup).to receive(:use_confirmation_codes).and_return(false)
+        end
+
+        it "redirects to new_user_session_path" do
+          post :create, params: params
+
+          expect(response).to redirect_to(decidim_router.user_confirmation_path)
+        end
+      end
+
+      describe "POST #create" do
+        it_behaves_like "confirmation codes disabled"
+
+        context "with a valid form" do
+          it "confirms the user and redirects" do
+            post :create, params: params
+
+            expect(user.reload).to be_confirmed
+            expect(response).to redirect_to(decidim_router.root_path)
+            expect(flash[:success]).to be_present
+          end
+
+          it "using confirmation_numbers params" do
+            post :create, params: {confirmation_token: user.confirmation_token, confirmation_numbers: [1,2,3,4] }
+
+            expect(user.reload).to be_confirmed
+            expect(response).to redirect_to(decidim_router.root_path)
+            expect(flash[:success]).to be_present
+          end
+        end
+
+        context "with an invalid form" do
+          it "redirects to new_user_session_path with an alert" do
+            post :create, params: { code: 9999 }
+
+            expect(response).to redirect_to(decidim_router.new_user_session_path)
+            expect(flash.now[:alert]).to be_present
+            expect(user.reload).not_to be_confirmed
+          end
+        end
+      end
+
+      describe "GET #skip" do
+        it_behaves_like "confirmation codes disabled"
+
+        it "signs in and redirects the user" do
+          get :skip, params: params
+          expect(response).to redirect_to("/")
+        end
+      end
+
+      describe "#confirmation_token" do
+        before do
+          allow(controller).to receive(:params).and_return(confirmation_token: "1234")
+        end
+
+        it "returns the confirmation_token" do
+          expect(controller.send(:confirmation_token)).to eq("1234")
+        end
+
+        context "when confirmation_token is an array" do
+          before do
+            allow(controller).to receive(:params).and_return(confirmation_token: ["1234", "4567", "6789"])
+          end
+
+          it "returns the first confirmation_token" do
+            expect(controller.send(:confirmation_token)).to eq("1234")
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/confirmation_codes_controller_spec.rb
+++ b/spec/controllers/confirmation_codes_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 module Decidim
@@ -43,7 +45,7 @@ module Decidim
           end
 
           it "using confirmation_numbers params" do
-            post :create, params: {confirmation_token: user.confirmation_token, confirmation_numbers: [1,2,3,4] }
+            post :create, params: { confirmation_token: user.confirmation_token, confirmation_numbers: [1, 2, 3, 4] }
 
             expect(user.reload).to be_confirmed
             expect(response).to redirect_to(decidim_router.root_path)
@@ -62,15 +64,6 @@ module Decidim
         end
       end
 
-      describe "GET #skip" do
-        it_behaves_like "confirmation codes disabled"
-
-        it "signs in and redirects the user" do
-          get :skip, params: params
-          expect(response).to redirect_to("/")
-        end
-      end
-
       describe "#confirmation_token" do
         before do
           allow(controller).to receive(:params).and_return(confirmation_token: "1234")
@@ -82,7 +75,7 @@ module Decidim
 
         context "when confirmation_token is an array" do
           before do
-            allow(controller).to receive(:params).and_return(confirmation_token: ["1234", "4567", "6789"])
+            allow(controller).to receive(:params).and_return(confirmation_token: %w(1234 4567 6789))
           end
 
           it "returns the first confirmation_token" do

--- a/spec/system/examples/confirmation_codes_examples.rb
+++ b/spec/system/examples/confirmation_codes_examples.rb
@@ -24,13 +24,9 @@ shared_examples "on/off confirmation codes" do
 
     context "when fast sign_up is activated" do
       before do
-        # Mock the value of unconfirmed_access_for to 2 days
         allow(Decidim).to receive(:unconfirmed_access_for).and_return(2.days)
-
-        # Mock the user's active_for_authentication? to always return true
         allow_any_instance_of(Decidim::User).to receive(:active_for_authentication?).and_return(true) # rubocop:disable RSpec/AnyInstance
 
-        # Visit the confirmation_codes_path with a confirmation token
         visit decidim_friendly_signup.confirmation_codes_path(confirmation_token: confirmation_token)
       end
 
@@ -40,43 +36,17 @@ shared_examples "on/off confirmation codes" do
         click_link "You can also participate during 2 days"
 
         expect(user.reload).not_to be_confirmed
+        expect(page).to have_current_path("/")
       end
 
       context "when we come to the end of the 2 days period" do
         before do
-          click_link "You can also participate during 2 days"
-
           travel_to 3.days.from_now
-
-          allow_any_instance_of(Decidim::User).to receive(:active_for_authentication?).and_return(false) # rubocop:disable RSpec/AnyInstance
         end
 
-        it "redirects you to the confirmation_page after two days" do
-          click_link user.name.to_s
-          click_link "Sign out"
-
-          expect(page).to have_content("Sign In")
-
-          click_link "Sign In"
-
-          fill_in "Email", with: user.email
-          fill_in "Password", with: user.password
-
-          click_button "Log in"
-
-          expect(page).to have_content("Sorry, this code has expired, please generate a new one.")
-
-          fill_in "Email", with: user.email
-
-          click_button "Resend confirmation instructions"
-
+        it "redirects user to the confirmation_page after two days" do
           expect(page).to have_content("You should receive a 4 digit code at #{user.email}")
-
-          expect(page).not_to have_content("You can also participate during 2 days")
-
-          within_flash_messages do
-            expect(page).to have_content("A message with a code has been sent to your email address. Please copy and paste the received code in this page.")
-          end
+          expect(page).to have_content("Didn't receive the code?")
         end
       end
     end

--- a/spec/system/examples/registration_hide_nickname_examples.rb
+++ b/spec/system/examples/registration_hide_nickname_examples.rb
@@ -29,7 +29,7 @@ shared_examples "on/off registration hide nickname" do
       expect(last_user.nickname).to eq("agent_smith_2")
     end
 
-    context "and use_confirmation_codes is disabled" do
+    context "and use_confirmation_codes is enabled" do
       before do
         allow(Decidim::FriendlySignup).to receive(:use_confirmation_codes).and_return(true)
       end


### PR DESCRIPTION
#### Description

Remove not necessary `GET` skip route on code_confirmations_controller.

#### How to test 

* Generate development_app
* Set env var `DECIDIM_UNCONFIRMED_ACCESS_FOR=2`
* Enable code confirmation
* Signup
* You should already be signed up on the confirmation code page
* You should also have a link "You can also participate during 2 days" redirecting to "/"

Change date of `confirmation_sent_at` to 3 days ago

* Try to log in
* You should be redirected to confirmation path with no link "You can also participate during 2 days"


#### Tasks
- [x] Remove Skip route in controller
- [x] Ensure `confirmation_token` param in code confirmation controller is not an array
- [x] Ensure `confirmation_token` param in code confirmation controller has a maxlength of 4
- [x] Add specs 