### PR TITLE
fix: Disable user confirmations when confirmation code

### DIFF
--- a/app/controllers/concerns/decidim/friendly_signup/registrations_redirect.rb
+++ b/app/controllers/concerns/decidim/friendly_signup/registrations_redirect.rb
@@ -8,6 +8,15 @@ module Decidim
       extend ActiveSupport::Concern
 
       included do
+        def show
+          if Decidim::FriendlySignup.use_confirmation_codes.present?
+            respond_with_navigational(resource){ redirect_to decidim.new_user_confirmation_path }
+            return
+          end
+
+          super
+        end
+
         def after_sign_up_path_for(user)
           codes_confirmation_path(user) || super(user)
         end

--- a/app/controllers/concerns/decidim/friendly_signup/registrations_redirect.rb
+++ b/app/controllers/concerns/decidim/friendly_signup/registrations_redirect.rb
@@ -10,7 +10,7 @@ module Decidim
       included do
         def show
           if Decidim::FriendlySignup.use_confirmation_codes.present?
-            respond_with_navigational(resource){ redirect_to decidim.new_user_confirmation_path }
+            respond_with_navigational(resource) { redirect_to decidim.new_user_confirmation_path }
             return
           end
 


### PR DESCRIPTION
#### Description

When confirmation code is enabled, default confirmation should be deactivated