### PR TITLE
fix: Disable button to avoid multiple validations

### DIFF
--- a/app/packs/src/decidim/friendly_signup/setup_confirmations.js
+++ b/app/packs/src/decidim/friendly_signup/setup_confirmations.js
@@ -13,6 +13,7 @@ $(() => {
       $inputBox.val(values[index]);
       $inputBox = $inputBox.next('input[type="number"]');
       if ($inputBox.length === 0) {
+        $form.find('button[type="submit"]').prop("disabled", true);
         $form.submit();
       }
     });


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

This Pull Request changes the behavior of the JS related to the confirmation form to avoid multiple validations by the user by disabling the button when the form is validating itself.

#### 🔧 How to test 

- Access the Registration Form
- Register as a new user
- Access the confirmation page
- Confirm your code and make sure your button is disabled and that you cannot validate again your form.

#### Tasks
- [x] Modify JS 
